### PR TITLE
Update nextGEMS Interface to Support Multiple Simulations

### DIFF
--- a/synsatipy/data_handler.py
+++ b/synsatipy/data_handler.py
@@ -186,6 +186,7 @@ class DataHandler(object):
 
         # stack the full data array
         stacked_input_data = self.input_data.stack(profile=profile_dimensions)
+#        stacked_input_data = stacked_input_data.chunk('auto') 
 
         full_index = np.arange(stacked_input_data.sizes['profile'])
 
@@ -277,16 +278,26 @@ class DataHandler(object):
         zeros = np.zeros_like(profs["p"].data.T)
         ones = zeros[:, :1] + 1
 
-        
+        # get pressure and define order
+        p = profs["p"].data.T * 1e-2  # in hPa
+
+        p_last_profile = p[-1, :]
+
+        if p_last_profile[0] < p_last_profile[-1]:
+            order = 'top-to-bottom'
+        else:
+            order = 'bottom-to-top'
+
+
         # fill profile
         q = profs["q"].data.T
         Temp =  profs["t"].data.T
 
         Temp = np.clip(Temp, 100, 400) 
 
-        myProfiles.P = profs["p"].data.T * 1e-2  # in hPa
-        myProfiles.T = Temp # gas_units = 1 => kg/kg over moist air (default)
-        myProfiles.Q = q
+        myProfiles.P = p
+        myProfiles.T = Temp 
+        myProfiles.Q = q # gas_units = 1 => kg/kg over moist air (default)
 
         # get satellite angles
         lon, lat = profs["lon"].data, profs["lat"].data
@@ -312,7 +323,12 @@ class DataHandler(object):
         T2m = np.expand_dims(profs["T2M"], axis=1)
         T2m = np.clip(T2m, 200, 400) 
 
-        q2m = np.expand_dims(q[:, 0], axis=1)  # only dew point there
+        if order == 'bottom-to-top':
+            q2m = np.expand_dims(q[:, 0], axis=1)  # only dew point there
+        elif order == 'top-to-bottom':
+            q2m = np.expand_dims(q[:, -1], axis=1)  # only dew point there
+
+        
 
         myProfiles.S2m = np.hstack([ps2m, T2m, q2m, zeros[:, :3]])
 

--- a/synsatipy/data_handler.py
+++ b/synsatipy/data_handler.py
@@ -186,7 +186,6 @@ class DataHandler(object):
 
         # stack the full data array
         stacked_input_data = self.input_data.stack(profile=profile_dimensions)
-#        stacked_input_data = stacked_input_data.chunk('auto') 
 
         full_index = np.arange(stacked_input_data.sizes['profile'])
 

--- a/synsatipy/input_nextgems.py
+++ b/synsatipy/input_nextgems.py
@@ -44,10 +44,10 @@ def open_ngdataset(cat_path, **kwargs):
 
     cat = intake.open_catalog(cat_path)
 
-    if simulation_name == 'ngc4008a':
-        frequency = 'PT15M'
+    if simulation_name == "ngc4008a":
+        frequency = "PT15M"
     else:
-        frequency = 'P1D'   
+        frequency = "P1D"
 
     dset = (
         cat.ICON[simulation_name](zoom=zoom, time=frequency)  # chunks="auto",

--- a/synsatipy/input_nextgems.py
+++ b/synsatipy/input_nextgems.py
@@ -40,11 +40,17 @@ def open_ngdataset(cat_path, **kwargs):
     """
 
     zoom = kwargs.get("zoom", 9)
+    simulation_name = kwargs.get("simulation_name", "ngc4008a")
 
     cat = intake.open_catalog(cat_path)
 
+    if simulation_name == 'ngc4008a':
+        frequency = 'PT15M'
+    else:
+        frequency = 'P1D'   
+
     dset = (
-        cat.ICON.ngc4008a(zoom=zoom, time="PT15M")  # chunks="auto",
+        cat.ICON[simulation_name](zoom=zoom, time=frequency)  # chunks="auto",
         .to_dask()
         .pipe(attach_coords)
     )
@@ -268,7 +274,7 @@ def open_nextgems(cat_path, name_remapping=True, **kwargs):
 
     dset["clc"] = xr.where(q_tot < q_tot_thresh, O, I)
 
-    dset = dset.transpose("time", "cell", "level_full", "level_half")
+    dset = dset.transpose("time", "cell", "level_full", "level_half", ...)
 
     if name_remapping:
         return nextgems_variable_mapping(dset)

--- a/synsatipy/input_nextgems.py
+++ b/synsatipy/input_nextgems.py
@@ -29,6 +29,11 @@ def open_ngdataset(cat_path, **kwargs):
     zoom : int, optional
         Zoom level. Default is 9.
 
+    simulation_name : str, optional
+        Name of the nextGEMS simulation to open. Default is ``"ngc4008a"``.
+        The output frequency is selected automatically based on the simulation:
+        ``"PT15M"`` for ``"ngc4008a"``, and ``"P1D"`` for all other simulations.
+
     Returns
     -------
     dset : xarray.Dataset


### PR DESCRIPTION
This PR extends the nextGEMS input interface to work with simulation datasets beyond the previously hard-coded `ngc4008a` run, and fixes a related bug in the profile handling of the data handler.

## Changes

- **Multi-simulation support** (`input_nextgems.py`): `open_ngdataset()` now accepts a `simulation_name` keyword argument (default: `ngc4008a`) and selects the appropriate output frequency (`PT15M` for `ngc4008a`, `P1D` otherwise).
- **Transpose fix** (`input_nextgems.py`): Added `...` to the `dset.transpose()` call to gracefully handle datasets with extra dimensions (e.g. `depth_half`, `soil_depth_water_level`), preventing a `ValueError` when additional dimensions are present.
- **Level order detection** (`data_handler.py`): Added logic to determine whether pressure profiles are ordered top-to-bottom or bottom-to-top, ensuring correct extraction of near-surface humidity (`q2m`) regardless of the vertical ordering convention of the input dataset.

