### PR TITLE
Aerosol Support & MODIS/EOS Instrument Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,49 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.2.0] 2026-08-03
 
+### Added
+
+#### Aerosol Support
+- New `aerosoltools` module for CAMS/OPAC aerosol species mapping and number-to-mass conversion
+- `use_aerosols` parameter for DataHandler and SynSat workflows with configurable species
+- HAMlite aerosol processing pipeline with automatic file detection and integration
+- Support for aerosol file handling in RTTOV via `FileScaer` coefficient files
+
+#### MODIS/EOS Instrument Support
+- New `load_eos_modis()` method supporting EOS-1 (Terra) and EOS-2 (Aqua) satellites
+- All 36 MODIS bands (0.4–14.4 μm) with default channel selection (thermal/water vapor bands 20, 22, 27–29, 31–33)
+- Polar-orbiting geometry handling with dynamic subsatellite longitude support
+- MODIS coefficient file integration for both Terra and Aqua variants
+
+#### Data Handler
+- HAMlite flavor detection and processing pipeline
+- Support for external geofile input via `geofile` parameter
+- New `hamlite01` example dataset
+
+### Changed
+
+#### Core Processing
+- Modified gas stacking in `data2profile()` to accommodate aerosols (list-based instead of `np.stack()`)
+- Enhanced GasId mapping to include aerosol RTTOV IDs (81–89 for CAMS species)
+- Added pressure level ordering detection (top-to-bottom vs bottom-to-top) for correct surface variable assignment
+- Improved subsatellite longitude handling with optional nadir-only viewing geometry support
+
+#### Instrument Configuration
+- Extended `load_instrument()` to support "modis" alongside "seviri", "abi", and "fci"
+- HAMlite file naming refactored with explicit `hamlite-aerosols` flavor variant
+
+#### Tests & Examples
+- Parametrized test cases for MODIS satellite variants
+- Centralized example data paths under `/work/bb1376/data/synsatipy/example-data/`
+- Updated test infrastructure to support geofile return options
+
+### Fixed
+
+- Proper handling of `lon0=None` for nadir-only viewing geometry (sets azimuth/zenith to zero)
+- Correct surface humidity extraction based on pressure level ordering
+- Code formatting and style consistency throughout
 
 ## [1.1.0] - 2025-11-14
 

--- a/synsatipy/data_handler.py
+++ b/synsatipy/data_handler.py
@@ -142,7 +142,8 @@ class DataHandler(object):
         """
         isel = kwargs.pop("isel", None)
         lon0 = kwargs.pop("lon0", 0.0)
-
+        use_aerosols = kwargs.pop("use_aerosols", False)
+            
         if self.model == "auto":
             model = autodetect_model_by_filename(filename)
         else:
@@ -156,8 +157,7 @@ class DataHandler(object):
 
         elif model == "icon":
             #            from input_icon import open_icon
-
-            indat = input_icon.open_icon(filename, **kwargs)
+            indat = input_icon.open_icon(filename, use_aerosols=use_aerosols, **kwargs)
 
         elif model == "nextgems":
             #            from input_icon import open_icon
@@ -253,6 +253,9 @@ class DataHandler(object):
             snow_factor = kwargs["synsat_snow_factor"]
         else:
             use_snow_factor = False
+
+        use_aerosols = kwargs.get("synsat_use_aerosols", False)
+        aerosol_species = kwargs.get("synsat_aerosol_species", {})
 
         lon0 = kwargs.pop("lon0", 0.0)
 

--- a/synsatipy/data_handler.py
+++ b/synsatipy/data_handler.py
@@ -13,7 +13,7 @@ import synsatipy.input_era as input_era
 import synsatipy.input_nextgems as input_nextgems
 
 from synsatipy.utils.spacetools import lonlat2azizen
-
+import synsatipy.utils.aerosoltools as aerosoltools
 
 ######################################################################
 ######################################################################
@@ -143,7 +143,8 @@ class DataHandler(object):
         isel = kwargs.pop("isel", None)
         lon0 = kwargs.pop("lon0", 0.0)
         use_aerosols = kwargs.pop("use_aerosols", False)
-            
+        aerosol_config = kwargs.get("aerosol_config", {})
+        
         if self.model == "auto":
             model = autodetect_model_by_filename(filename)
         else:
@@ -169,6 +170,9 @@ class DataHandler(object):
             self.input_data = indat.isel(**isel)
         else:
             self.input_data = indat
+
+        self.use_aerosols = use_aerosols
+        self.aerosol_config = aerosol_config
 
 
     def stack_data_as_profile(self, **kwargs):
@@ -254,8 +258,8 @@ class DataHandler(object):
         else:
             use_snow_factor = False
 
-        use_aerosols = kwargs.get("synsat_use_aerosols", False)
-        aerosol_species = kwargs.get("synsat_aerosol_species", {})
+        use_aerosols = self.use_aerosols
+        aerosol_config = self.aerosol_config
 
         lon0 = kwargs.pop("lon0", 0.0)
 
@@ -359,10 +363,30 @@ class DataHandler(object):
 
         cc = profs["cc"].data.T
 
-        gases = np.stack([q, cc, qc, q_frozen])
+        gases = [q, cc, qc, q_frozen]
+        gas_ids = [1, 20, 21, 30]  # H2O, Cloud fraction, Liquid water content, Frozen water content
+        
+        
+        if use_aerosols:
+            aerosol_mass_list = []
+            aerosol_id_list = []
+            
+            for aerosol_name in aerosol_config:
+                print(f"Processing aerosol species '{aerosol_name}'...")
+                target_name = aerosol_config[aerosol_name]["target_name"]
+                CAMS_OPAC_name = aerosol_config[aerosol_name]["CAMS_OPAC_name"]
+                rttov_id = aerosoltools._cams_rttov_id_mapping[ CAMS_OPAC_name ]
+
+                aerosol_mass = profs[target_name].data.T
+                aerosol_mass_list += [aerosol_mass,]
+                aerosol_id_list += [rttov_id,]
+
+                gases += [aerosol_mass]
+                gas_ids += [rttov_id]
+                
         myProfiles.MmrCldAer = 1
-        myProfiles.Gases = gases
-        myProfiles.GasId = np.array([1, 20, 21, 30])
+        myProfiles.Gases = np.stack(gases)
+        myProfiles.GasId = np.array(gas_ids)
 
         # this is Baum + McFarquhar
         myProfiles.IceCloud = np.hstack(

--- a/synsatipy/data_handler.py
+++ b/synsatipy/data_handler.py
@@ -300,7 +300,12 @@ class DataHandler(object):
 
         # get satellite angles
         lon, lat = profs["lon"].data, profs["lat"].data
-        azi, zen = lonlat2azizen(lon, lat, lon0=lon0)
+        if lon0 is not None:
+            azi, zen = lonlat2azizen(lon, lat, lon0=lon0)
+        else:
+            # currently we treat all positions as nadir viewing, so set angles to zero
+            print("... [synsat]: no satellite longitude provided, treating all positions as nadir viewing.")
+            azi, zen = 0*lon, 0*lat
 
         # set max zen angle
         zen = np.clip(zen, 0, 80)

--- a/synsatipy/data_handler.py
+++ b/synsatipy/data_handler.py
@@ -121,6 +121,8 @@ class DataHandler(object):
     def __init__(self, model="auto", return_profile=True, **kwargs):
 
         self.model = model
+        self.use_aerosols = kwargs.pop("use_aerosols", False)
+        self.aerosol_config = kwargs.get("aerosol_config", {})
 
         return
 

--- a/synsatipy/data_handler.py
+++ b/synsatipy/data_handler.py
@@ -84,7 +84,7 @@ def autodetect_model_by_filename(fname):
         if k in fname:
             model = "era"
 
-    icon_keys = ["icon", "ifces"]
+    icon_keys = ["icon", "ifces", "hamlite"]
 
     for k in icon_keys:
         if k in fname:

--- a/synsatipy/input_icon.py
+++ b/synsatipy/input_icon.py
@@ -145,6 +145,10 @@ def icon_name_creator(icon_name_props):
         icon_name = "{fullpath}/{domain}_{model_component}_{data_type}_{variable_stack}_{level_type}_{time_str}.nc".format(
             **icon_name_props
         )
+    elif flavor == "hamlite-aerosols":
+        icon_name = "{fullpath}/hamlite_trc_{data_type}_{level_type}_{time_str}.nc".format(
+            **icon_name_props
+        )
 
     return icon_name
 
@@ -332,6 +336,8 @@ def open_icon(
 
     """
 
+    use_aerosols = kwargs.get("use_aerosols", False)
+
     if geofile is not None:
         georef = read_georef(geofile)
     else:
@@ -471,6 +477,39 @@ def open_icon(
     if flavor == "ifces2":
         t = timetools.convert_timevec(icon.time.data)
         icon = icon.assign_coords({"time": t})
+
+    if flavor == "hamlite" and use_aerosols:
+        # HAMLite time is in seconds since 1970-01-01, but icon3dbase.time is already in datetime64[ns]
+        # so we can directly assign it without conversion.
+        print('... transforming and adding aerosols to HAMLite dataset')
+
+        icon_name_props.update(
+            {
+                "data_type": "3d",
+                "flavor": "hamlite-aerosols"            
+            }
+        )
+        icon_aerosol_name = icon_name_creator( icon_name_props )
+        icon_aerosol = xr.open_dataset(icon_aerosol_name, **input_options)
+
+        # select base time
+        icon_aerosol = icon_aerosol.sel(
+            time=icon.time, method="nearest"
+        )
+
+        # only select aerosol variables
+        aerosol_varlist = []
+        for vname in icon_aerosol.data_vars:
+            if 'num' in vname:
+                aerosol_varlist += [ vname,]
+
+        icon_aerosol = icon_aerosol[aerosol_varlist]
+
+        print(icon_aerosol.time)
+        print(icon.time)
+
+
+        icon = xr.merge([icon, icon_aerosol], compat="override")
 
     if name_remapping:
         return icon_variable_mapping(icon, flavor=flavor, always_keep=always_keep)

--- a/synsatipy/input_icon.py
+++ b/synsatipy/input_icon.py
@@ -8,6 +8,8 @@ import xarray as xr
 
 
 import synsatipy.utils.timetools as timetools
+import synsatipy.utils.aerosoltools as aerosoltools
+
 
 
 def icon_name_analyzer(icon_name):
@@ -337,6 +339,7 @@ def open_icon(
     """
 
     use_aerosols = kwargs.get("use_aerosols", False)
+    aerosol_config = kwargs.get("aerosol_config", {} )
 
     if geofile is not None:
         georef = read_georef(geofile)
@@ -505,11 +508,18 @@ def open_icon(
 
         icon_aerosol = icon_aerosol[aerosol_varlist]
 
-        print(icon_aerosol.time)
-        print(icon.time)
+        # aerosol number to mass conversion
+        icon_aerosol_mass = aerosoltools.convert_hamlite_numberconc_in_massconc(
+            icon_aerosol,
+            aerosol_config
+        )
+
+        aerosol_targetnames = aerosoltools.target_name_list( aerosol_config )
+        always_keep += aerosol_targetnames
+
+        icon = xr.merge([icon, icon_aerosol_mass], compat="override")
 
 
-        icon = xr.merge([icon, icon_aerosol], compat="override")
 
     if name_remapping:
         return icon_variable_mapping(icon, flavor=flavor, always_keep=always_keep)

--- a/synsatipy/synsat.py
+++ b/synsatipy/synsat.py
@@ -106,6 +106,23 @@ class SynSatBase(pyrttov.Rttov, synsat_attributes):
 
         self.synsat.nprofiles = None
 
+        # aerosol options
+        use_aerosols = synsat_kwargs.get("synsat_use_aerosols", False)
+        self.Options.AddAerosl = use_aerosols
+        self.synsat.use_aerosols = use_aerosols
+        # maps hamlite variable names -> RTTOV aerosol gas IDs
+        # see RTTOV user guide table of gas/aerosol IDs
+        self.synsat.aerosol_species = synsat_kwargs.get(
+            "synsat_aerosol_species",
+            {
+                "aer_so4": 41,  # sulphate
+                "aer_bc": 42,  # black carbon
+                "aer_oc": 43,  # organic carbon
+                "aer_du1": 47,  # mineral dust (coarse)
+                "aer_ss1": 51,  # sea salt (coarse)
+            },
+        )
+
         return
 
     def load_instrument(self, **synsat_kwargs):
@@ -123,7 +140,6 @@ class SynSatBase(pyrttov.Rttov, synsat_attributes):
         """
 
         implemented_instruments = ["seviri", "abi", "fci", "modis"]
-
 
         # Default to SEVIRI if not specified
         instrument = synsat_kwargs.get("synsat_instrument", "seviri").lower()
@@ -316,7 +332,7 @@ class SynSatBase(pyrttov.Rttov, synsat_attributes):
             "rho137",
             "rho160",
             "rho220",
-            "bt039",   # Brightness temperature channels (7-16)
+            "bt039",  # Brightness temperature channels (7-16)
             "bt062",
             "bt069",
             "bt073",
@@ -328,20 +344,24 @@ class SynSatBase(pyrttov.Rttov, synsat_attributes):
             "bt133",
         ]
 
-        abi_var_units = (
-            6 * ["-",] + 10 * ["K",]
-        )
+        abi_var_units = 6 * [
+            "-",
+        ] + 10 * [
+            "K",
+        ]
 
         # GOES-ABI options
         # ===========
         # Default to IR channels (channels 7-16)
         default_chan_list = (7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
-        chan_list_instrument = synsat_kwargs.get("synsat_channel_list", default_chan_list)
+        chan_list_instrument = synsat_kwargs.get(
+            "synsat_channel_list", default_chan_list
+        )
 
         attr = self.synsat
         attr.instrument = "ABI"
 
-        subsatellite_lon = synsat_kwargs.get("synsat_subsatellite_lon",  -75.2)
+        subsatellite_lon = synsat_kwargs.get("synsat_subsatellite_lon", -75.2)
         attr.subsatellite_lon = subsatellite_lon
 
         chan_index = np.array(chan_list_instrument) - 1
@@ -395,24 +415,24 @@ class SynSatBase(pyrttov.Rttov, synsat_attributes):
         # FCI specifics
         # ================
         fci_allchannel_names = [
-            "vis04",   # 0.444 μm - Blue
-            "vis05",   # 0.510 μm - Green
-            "vis06",   # 0.640 μm - Red
-            "vis08",   # 0.865 μm - Vegetation Red Edge
-            "vis09",   # 0.914 μm - Water Vapour
-            "nir13",   # 1.375 μm - Cirrus
-            "nir16",   # 1.610 μm - Snow/Ice/Cloud Phase
-            "nir22",   # 2.250 μm - Aerosol/Cloud Particle Size
-            "ir38",    # 3.80 μm - Hot objects/Fire/Night microphysics
-            "wv63",    # 6.25 μm - Upper-Level Water Vapour
-            "wv73",    # 7.35 μm - Lower-Level Water Vapour
-            "ir87",    # 8.70 μm - Cloud Phase/SO2
-            "ir97",    # 9.66 μm - Ozone
-            "ir105",   # 10.50 μm - Clean IR Window
-            "ir123",   # 12.30 μm - Dirty IR Window
-            "ir133",   # 13.30 μm - CO2
+            "vis04",  # 0.444 μm - Blue
+            "vis05",  # 0.510 μm - Green
+            "vis06",  # 0.640 μm - Red
+            "vis08",  # 0.865 μm - Vegetation Red Edge
+            "vis09",  # 0.914 μm - Water Vapour
+            "nir13",  # 1.375 μm - Cirrus
+            "nir16",  # 1.610 μm - Snow/Ice/Cloud Phase
+            "nir22",  # 2.250 μm - Aerosol/Cloud Particle Size
+            "ir38",  # 3.80 μm - Hot objects/Fire/Night microphysics
+            "wv63",  # 6.25 μm - Upper-Level Water Vapour
+            "wv73",  # 7.35 μm - Lower-Level Water Vapour
+            "ir87",  # 8.70 μm - Cloud Phase/SO2
+            "ir97",  # 9.66 μm - Ozone
+            "ir105",  # 10.50 μm - Clean IR Window
+            "ir123",  # 12.30 μm - Dirty IR Window
+            "ir133",  # 13.30 μm - CO2
         ]
-        
+
         fci_var_names = [
             "rho044",  # Reflectivity channels (1-8)
             "rho051",
@@ -422,7 +442,7 @@ class SynSatBase(pyrttov.Rttov, synsat_attributes):
             "rho138",
             "rho161",
             "rho225",
-            "bt038",   # Brightness temperature channels (8-16)
+            "bt038",  # Brightness temperature channels (8-16)
             "bt063",
             "bt073",
             "bt087",
@@ -431,15 +451,19 @@ class SynSatBase(pyrttov.Rttov, synsat_attributes):
             "bt123",
             "bt133",
         ]
-        fci_var_units = (
-            8 * ["-",] + 8 * ["K",]
-        )
+        fci_var_units = 8 * [
+            "-",
+        ] + 8 * [
+            "K",
+        ]
 
         # MTG-FCI options
         # ===========
         # Default to IR and water vapor channels (channels 9-16)
         default_chan_list = (9, 10, 11, 12, 13, 14, 15, 16)
-        chan_list_instrument = synsat_kwargs.get("synsat_channel_list", default_chan_list)
+        chan_list_instrument = synsat_kwargs.get(
+            "synsat_channel_list", default_chan_list
+        )
 
         attr = self.synsat
         attr.instrument = "FCI"
@@ -498,7 +522,9 @@ class SynSatBase(pyrttov.Rttov, synsat_attributes):
 
         # Map satellite name to EOS number
         satellite_map = {"terra": 1, "aqua": 2}
-        satellite_name = synsat_kwargs.get("synsat_modis_satellite", synsat_modis_satellite).lower()
+        satellite_name = synsat_kwargs.get(
+            "synsat_modis_satellite", synsat_modis_satellite
+        ).lower()
         if satellite_name not in satellite_map:
             raise ValueError(
                 f"Unknown MODIS satellite '{satellite_name}'. "
@@ -531,35 +557,37 @@ class SynSatBase(pyrttov.Rttov, synsat_attributes):
             "rho093",  # 18 - 931-941 nm   (0.936µm → 93, floor to avoid clash with band 19)
             "rho094",  # 19 - 915-965 nm   (0.940µm → 94)
             # bt: centre_µm × 10, 3-digit zero-padded
-            "bt038",   # 20 - 3.660-3.840 µm (3.750µm → 038)
-            "bt039",   # 21 - 3.929-3.989 µm (fire channel; floor to avoid clash with band 22)
-            "bt040",   # 22 - 3.929-3.989 µm (3.959µm → 040)
-            "bt041",   # 23 - 4.020-4.080 µm (4.050µm → 041)
-            "bt045",   # 24 - 4.433-4.498 µm (4.466µm → 045)
-            "bt046",   # 25 - 4.482-4.549 µm (4.516µm → 046, ceil to avoid clash with band 24)
+            "bt038",  # 20 - 3.660-3.840 µm (3.750µm → 038)
+            "bt039",  # 21 - 3.929-3.989 µm (fire channel; floor to avoid clash with band 22)
+            "bt040",  # 22 - 3.929-3.989 µm (3.959µm → 040)
+            "bt041",  # 23 - 4.020-4.080 µm (4.050µm → 041)
+            "bt045",  # 24 - 4.433-4.498 µm (4.466µm → 045)
+            "bt046",  # 25 - 4.482-4.549 µm (4.516µm → 046, ceil to avoid clash with band 24)
             "rho138",  # 26 - 1.360-1.390 µm (1.375µm → 138, cirrus solar channel)
-            "bt067",   # 27 - 6.535-6.895 µm (6.715µm → 067)
-            "bt073",   # 28 - 7.175-7.475 µm (7.325µm → 073)
-            "bt086",   # 29 - 8.400-8.700 µm (8.550µm → 086)
-            "bt097",   # 30 - 9.580-9.880 µm (9.730µm → 097, ozone)
-            "bt110",   # 31 - 10.780-11.280 µm (11.030µm → 110)
-            "bt120",   # 32 - 11.770-12.270 µm (12.020µm → 120)
-            "bt133",   # 33 - 13.185-13.485 µm (13.335µm → 133)
-            "bt136",   # 34 - 13.485-13.785 µm (13.635µm → 136)
-            "bt139",   # 35 - 13.785-14.085 µm (13.935µm → 139)
-            "bt142",   # 36 - 14.085-14.385 µm (14.235µm → 142)
+            "bt067",  # 27 - 6.535-6.895 µm (6.715µm → 067)
+            "bt073",  # 28 - 7.175-7.475 µm (7.325µm → 073)
+            "bt086",  # 29 - 8.400-8.700 µm (8.550µm → 086)
+            "bt097",  # 30 - 9.580-9.880 µm (9.730µm → 097, ozone)
+            "bt110",  # 31 - 10.780-11.280 µm (11.030µm → 110)
+            "bt120",  # 32 - 11.770-12.270 µm (12.020µm → 120)
+            "bt133",  # 33 - 13.185-13.485 µm (13.335µm → 133)
+            "bt136",  # 34 - 13.485-13.785 µm (13.635µm → 136)
+            "bt139",  # 35 - 13.785-14.085 µm (13.935µm → 139)
+            "bt142",  # 36 - 14.085-14.385 µm (14.235µm → 142)
         ]
 
         modis_var_units = (
-            19 * ["-"] +   # bands 1-19: reflective
-            6  * ["K"]  +  # bands 20-25: thermal
-            ["-"]       +  # band  26: solar (cirrus)
-            9  * ["K"]     # bands 27-36: thermal
+            19 * ["-"]  # bands 1-19: reflective
+            + 6 * ["K"]  # bands 20-25: thermal
+            + ["-"]  # band  26: solar (cirrus)
+            + 9 * ["K"]  # bands 27-36: thermal
         )
 
         # Default channel list: key thermal/WV bands analogous to other instruments
         default_chan_list = (20, 22, 27, 28, 29, 31, 32, 33)
-        chan_list_instrument = synsat_kwargs.get("synsat_channel_list", default_chan_list)
+        chan_list_instrument = synsat_kwargs.get(
+            "synsat_channel_list", default_chan_list
+        )
 
         attr = self.synsat
         attr.instrument = f"MODIS ({satellite_name.capitalize()})"
@@ -577,12 +605,19 @@ class SynSatBase(pyrttov.Rttov, synsat_attributes):
 
         # Solar channels: bands 1-19 are always solar; band 26 (index 25) is also solar
         solar_indices = set(range(1, 20)) | {26}
-        attr.solar_calculations = any(ch in solar_indices for ch in chan_list_instrument)
+        attr.solar_calculations = any(
+            ch in solar_indices for ch in chan_list_instrument
+        )
 
         # Coefficient files
         cldaer_filename = f"{attr.rttov_install_dir}/rtcoef_rttov13/cldaer_visir/sccldcoef_eos_{eos_number}_modis.dat"
         self.FileSccld = cldaer_filename
-        print(f"... [synsat] set cloud / aerosol file to {cldaer_filename}")
+        print(f"... [synsat] set cloud file to {cldaer_filename}")
+
+        if attr.use_aerosols:
+            aer_filename = f"{attr.rttov_install_dir}/rtcoef_rttov13/cldaer_visir/scaercoef_eos_{eos_number}_modis_cams.dat"
+            self.FileScaer = aer_filename
+            print(f"... [synsat] set aerosol file to {aer_filename}")
 
         coef_filename = f"{attr.rttov_install_dir}/rtcoef_rttov13/rttov13pred54L/rtcoef_eos_{eos_number}_modis_o3.dat"
         self.FileCoef = coef_filename
@@ -760,7 +795,10 @@ class SynSat(SynSatBase):
         """
 
         model = kwargs.get("model", "auto")
-        lon0 = self.synsat.subsatellite_lon
+
+        attr = self.synsat
+        lon0 = attr.subsatellite_lon
+        use_aerosols = attr.use_aerosols
 
         # use data handler to load data
         sdat = data_handler.DataHandler(model=model)
@@ -773,7 +811,7 @@ class SynSat(SynSatBase):
 
             self.synsat.input_filename = inputfile
 
-            sdat.open_data(inputfile, lon0 = lon0, **kwargs)
+            sdat.open_data(inputfile, lon0=lon0, use_aerosols=use_aerosols, **kwargs)
 
         elif type(inputfile_or_data) == type(xr.Dataset()):
             sdat.input_data = inputfile_or_data
@@ -802,7 +840,7 @@ class SynSat(SynSatBase):
         sdat = self.synsat.data_handler
         lon0 = self.synsat.subsatellite_lon
 
-        profs = sdat.data2profile(lon0 = lon0, **kwargs)
+        profs = sdat.data2profile(lon0=lon0, **kwargs)
 
         # forward profiles to RTTOV
         self.Profiles = profs
@@ -880,32 +918,33 @@ class SynSat(SynSatBase):
         selected_indices = sdat.selected_profiles_index
 
         # Create a full-size result array filled with NaN
-        full_result = np.full((original_stacked.sizes['profile'], len(attr.channels)), np.nan)
-        
+        full_result = np.full(
+            (original_stacked.sizes["profile"], len(attr.channels)), np.nan
+        )
+
         # Fill in the results at the correct positions
         full_result[selected_indices, :] = self.synsat.result
-        
+
         # Create the DataArray with full coordinates AND attributes preserved
         channels = xr.DataArray(data=np.array(attr.channels), dims=["channel"])
 
         btrefl_full = xr.DataArray(
-            data=full_result, 
-            coords={
-                'profile': original_stacked.profile,
-                'channel': channels
-            },
-            dims=['profile', 'channel'],
-            attrs=original_stacked.attrs  # Preserve dataset-level attributes if needed
+            data=full_result,
+            coords={"profile": original_stacked.profile, "channel": channels},
+            dims=["profile", "channel"],
+            attrs=original_stacked.attrs,  # Preserve dataset-level attributes if needed
         )
 
         # Copy coordinate attributes from original stacked data
         for coord_name in original_stacked.coords:
             if coord_name in btrefl_full.coords:
-                btrefl_full.coords[coord_name].attrs = original_stacked.coords[coord_name].attrs
+                btrefl_full.coords[coord_name].attrs = original_stacked.coords[
+                    coord_name
+                ].attrs
 
         # Now unstack will work correctly and preserve coordinate attributes
         btrefl = btrefl_full.unstack()
-        
+
         # Start with the original input data structure to preserve coordinate attributes
         synsat = xr.Dataset()
 
@@ -919,7 +958,7 @@ class SynSat(SynSatBase):
             a["units"] = attr.units[ichan]
             a["long_name"] = "Synsat %s Brightness Temperature at %.1f um" % (
                 attr.instrument,
-                np.float32(chan_name[2:]) / 10.0
+                np.float32(chan_name[2:]) / 10.0,
             )
             synsat[chan_name].attrs = a
 

--- a/synsatipy/synsat.py
+++ b/synsatipy/synsat.py
@@ -783,13 +783,14 @@ class SynSat(SynSatBase):
         """
 
         model = kwargs.get("model", "auto")
+        aerosol_config = kwargs.get('aerosol_config', {})
 
         attr = self.synsat
         lon0 = attr.subsatellite_lon
         use_aerosols = attr.use_aerosols
 
         # use data handler to load data
-        sdat = data_handler.DataHandler(model=model)
+        sdat = data_handler.DataHandler(model=model, use_aerosols=use_aerosols, aerosol_config=aerosol_config)
 
         # check if file or dataset is provided
         if type(inputfile_or_data) == type(""):

--- a/synsatipy/synsat.py
+++ b/synsatipy/synsat.py
@@ -110,18 +110,6 @@ class SynSatBase(pyrttov.Rttov, synsat_attributes):
         use_aerosols = synsat_kwargs.get("synsat_use_aerosols", False)
         self.Options.AddAerosl = use_aerosols
         self.synsat.use_aerosols = use_aerosols
-        # maps hamlite variable names -> RTTOV aerosol gas IDs
-        # see RTTOV user guide table of gas/aerosol IDs
-        self.synsat.aerosol_species = synsat_kwargs.get(
-            "synsat_aerosol_species",
-            {
-                "aer_so4": 41,  # sulphate
-                "aer_bc": 42,  # black carbon
-                "aer_oc": 43,  # organic carbon
-                "aer_du1": 47,  # mineral dust (coarse)
-                "aer_ss1": 51,  # sea salt (coarse)
-            },
-        )
 
         return
 

--- a/synsatipy/synsat.py
+++ b/synsatipy/synsat.py
@@ -122,7 +122,7 @@ class SynSatBase(pyrttov.Rttov, synsat_attributes):
         None
         """
 
-        implemented_instruments = ["seviri", "abi", "fci"]
+        implemented_instruments = ["seviri", "abi", "fci", "modis"]
 
 
         # Default to SEVIRI if not specified
@@ -139,7 +139,11 @@ class SynSatBase(pyrttov.Rttov, synsat_attributes):
         elif instrument == "fci":
             # Load MTG-FCI configuration
             self.load_mtg_fci(**synsat_kwargs)
-        
+
+        elif instrument == "modis":
+            # Load EOS-MODIS configuration
+            self.load_eos_modis(**synsat_kwargs)
+
         else:
             print(
                 f"... [synsat] WARNING: {instrument} is not a valid instrument. "
@@ -467,6 +471,129 @@ class SynSatBase(pyrttov.Rttov, synsat_attributes):
         attr.coef_filename = coef_filename
 
         # Load the instruments
+        try:
+            self.loadInst(chan_list_instrument)
+        except self.RttovError as e:
+            sys.stderr.write("Error loading instrument(s): {!s}".format(e))
+            sys.exit(1)
+
+        return
+
+    def load_eos_modis(self, synsat_modis_satellite="terra", **synsat_kwargs):
+        """
+        Loads configuration specific for the EOS-MODIS instrument.
+
+        Parameters
+        ----------
+        synsat_modis_satellite : str
+            EOS satellite name, either 'terra' (EOS-1) or 'aqua' (EOS-2).
+            (Default value = 'terra')
+        **synsat_kwargs : dict
+            Additional keyword arguments.
+
+        Returns
+        -------
+        None
+        """
+
+        # Map satellite name to EOS number
+        satellite_map = {"terra": 1, "aqua": 2}
+        satellite_name = synsat_kwargs.get("synsat_modis_satellite", synsat_modis_satellite).lower()
+        if satellite_name not in satellite_map:
+            raise ValueError(
+                f"Unknown MODIS satellite '{satellite_name}'. "
+                f"Supported values are: {list(satellite_map.keys())}"
+            )
+        eos_number = satellite_map[satellite_name]
+
+        # MODIS channel definitions (bands 1-36)
+        # Bands 1-19: reflective solar (VIS/NIR, 0.4-2.2 µm)
+        # Bands 20-36: thermal emissive (3.7-14.4 µm), except band 26 (1.38 µm, solar)
+        modis_var_names = [
+            # rho: centre_µm × 100, 3-digit zero-padded
+            "rho064",  #  1 - 620-670 nm   (0.645µm → 64)
+            "rho086",  #  2 - 841-876 nm   (0.859µm → 86)
+            "rho047",  #  3 - 459-479 nm   (0.469µm → 47)
+            "rho056",  #  4 - 545-565 nm   (0.555µm → 56)
+            "rho124",  #  5 - 1230-1250 nm (1.240µm → 124)
+            "rho164",  #  6 - 1628-1652 nm (1.640µm → 164)
+            "rho213",  #  7 - 2105-2155 nm (2.130µm → 213)
+            "rho041",  #  8 - 405-420 nm   (0.413µm → 41)
+            "rho044",  #  9 - 438-448 nm   (0.443µm → 44)
+            "rho046",  # 10 - 438-493 nm   (0.466µm → 46, floor to avoid clash with band 3)
+            "rho053",  # 11 - 526-536 nm   (0.531µm → 53)
+            "rho055",  # 12 - 546-556 nm   (0.551µm → 55)
+            "rho067",  # 13 - 662-672 nm   (0.667µm → 67)
+            "rho068",  # 14 - 673-683 nm   (0.678µm → 68)
+            "rho075",  # 15 - 743-753 nm   (0.748µm → 75)
+            "rho087",  # 16 - 862-877 nm   (0.870µm → 87)
+            "rho091",  # 17 - 890-920 nm   (0.905µm → 91)
+            "rho093",  # 18 - 931-941 nm   (0.936µm → 93, floor to avoid clash with band 19)
+            "rho094",  # 19 - 915-965 nm   (0.940µm → 94)
+            # bt: centre_µm × 10, 3-digit zero-padded
+            "bt038",   # 20 - 3.660-3.840 µm (3.750µm → 038)
+            "bt039",   # 21 - 3.929-3.989 µm (fire channel; floor to avoid clash with band 22)
+            "bt040",   # 22 - 3.929-3.989 µm (3.959µm → 040)
+            "bt041",   # 23 - 4.020-4.080 µm (4.050µm → 041)
+            "bt045",   # 24 - 4.433-4.498 µm (4.466µm → 045)
+            "bt046",   # 25 - 4.482-4.549 µm (4.516µm → 046, ceil to avoid clash with band 24)
+            "rho138",  # 26 - 1.360-1.390 µm (1.375µm → 138, cirrus solar channel)
+            "bt067",   # 27 - 6.535-6.895 µm (6.715µm → 067)
+            "bt073",   # 28 - 7.175-7.475 µm (7.325µm → 073)
+            "bt086",   # 29 - 8.400-8.700 µm (8.550µm → 086)
+            "bt097",   # 30 - 9.580-9.880 µm (9.730µm → 097, ozone)
+            "bt110",   # 31 - 10.780-11.280 µm (11.030µm → 110)
+            "bt120",   # 32 - 11.770-12.270 µm (12.020µm → 120)
+            "bt133",   # 33 - 13.185-13.485 µm (13.335µm → 133)
+            "bt136",   # 34 - 13.485-13.785 µm (13.635µm → 136)
+            "bt139",   # 35 - 13.785-14.085 µm (13.935µm → 139)
+            "bt142",   # 36 - 14.085-14.385 µm (14.235µm → 142)
+        ]
+
+        modis_var_units = (
+            19 * ["-"] +   # bands 1-19: reflective
+            6  * ["K"]  +  # bands 20-25: thermal
+            ["-"]       +  # band  26: solar (cirrus)
+            9  * ["K"]     # bands 27-36: thermal
+        )
+
+        # Default channel list: key thermal/WV bands analogous to other instruments
+        default_chan_list = (20, 22, 27, 28, 29, 31, 32, 33)
+        chan_list_instrument = synsat_kwargs.get("synsat_channel_list", default_chan_list)
+
+        attr = self.synsat
+        attr.instrument = f"MODIS ({satellite_name.capitalize()})"
+
+        # MODIS is polar-orbiting — subsatellite_lon is not physically meaningful
+        # but kept as a dummy for interface compatibility
+        subsatellite_lon = synsat_kwargs.get("synsat_subsatellite_lon", None)
+        attr.subsatellite_lon = subsatellite_lon
+
+        chan_index = np.array(chan_list_instrument) - 1
+
+        attr.channels = np.array(modis_var_names)[chan_index]
+        attr.units = np.array(modis_var_units)[chan_index]
+        nchan_instrument = len(chan_list_instrument)
+
+        # Solar channels: bands 1-19 are always solar; band 26 (index 25) is also solar
+        solar_indices = set(range(1, 20)) | {26}
+        attr.solar_calculations = any(ch in solar_indices for ch in chan_list_instrument)
+
+        # Coefficient files
+        cldaer_filename = f"{attr.rttov_install_dir}/rtcoef_rttov13/cldaer_visir/sccldcoef_eos_{eos_number}_modis.dat"
+        self.FileSccld = cldaer_filename
+        print(f"... [synsat] set cloud / aerosol file to {cldaer_filename}")
+
+        coef_filename = f"{attr.rttov_install_dir}/rtcoef_rttov13/rttov13pred54L/rtcoef_eos_{eos_number}_modis_o3.dat"
+        self.FileCoef = coef_filename
+        print(f"... [synsat] load coefficient file {coef_filename}")
+
+        # Save vars to attributes
+        attr.chan_list_instrument = chan_list_instrument
+        attr.nchan_instrument = nchan_instrument
+        attr.coef_filename = coef_filename
+
+        # Load the instrument
         try:
             self.loadInst(chan_list_instrument)
         except self.RttovError as e:

--- a/synsatipy/synsat_example_data.py
+++ b/synsatipy/synsat_example_data.py
@@ -1,4 +1,4 @@
-import os, sys
+import socket
 
 
 def get_example_data(example_name, stored_on_server=True, return_geofile=False):
@@ -10,26 +10,32 @@ def get_example_data(example_name, stored_on_server=True, return_geofile=False):
     ----------
     example_name : str
         The name of the example data.
-        Possible values are "era01", "icon01", "icon02".
+        Possible values are "era01", "icon01", "icon02", "hamlite01".
 
     stored_on_server : bool, optional
         If the data is stored on the server. Default is True.
         Check the server name and set this parameter False if the server is unknown.
         Possible servers are "tropos", "dkrz".
 
+    return_geofile : bool, optional
+        If True, return the path to the geofile as well. Default is False.
+        
     Returns
     -------
     fname : str
-        The file name of the example data
+        The file name of the example data. If <return_geofile> is True, a tuple
+        (fname, geofile) is returned, where <geofile> is the path to the geofile.
 
     Notes
     -----
     The example data is stored on the server.
     """
-    
+
+    if return_geofile:
+        geofile = None
 
     if stored_on_server:
-        hostname = os.uname()[1]
+        hostname = socket.getfqdn()
 
         if "tropos.de" in hostname:
             server = "tropos"

--- a/synsatipy/synsat_example_data.py
+++ b/synsatipy/synsat_example_data.py
@@ -1,7 +1,7 @@
 import os, sys
 
 
-def get_example_data(example_name, stored_on_server=True):
+def get_example_data(example_name, stored_on_server=True, return_geofile=False):
 
     """
     Get the example data.
@@ -47,7 +47,7 @@ def get_example_data(example_name, stored_on_server=True):
             fname = f"{dirname}/era5-3d-medi-2020-09-15.nc"
 
         elif server == "dkrz":
-            dirname = "/work/bb1262/data/era5/medi/2020"
+            dirname = "/work/bb1376/data/synsatipy/example-data/era5"
             fname = f"{dirname}/era5-3d-medi-2020-09-15.nc"
 
     if example_name == "icon01":
@@ -57,7 +57,7 @@ def get_example_data(example_name, stored_on_server=True):
             fname = f"{dirname}/3d_full_base_DOM01_ML_20200912T000000Z_regrid7km.nc"
 
         elif server == "dkrz":
-            dirname = "/work/bb1376/data/icon/atlantic-cases/paulette/ifces2-atlanXL-20200907-exp021/POSTPROC/"
+            dirname = "/work/bb1376/data/synsatipy/example-data/ifces2"
             fname = f"{dirname}/3d_full_base_DOM01_ML_20200912T000000Z_regrid7km.nc"
 
     if example_name == "icon02":
@@ -67,10 +67,22 @@ def get_example_data(example_name, stored_on_server=True):
             fname = f"{dirname}/3d_full_base_DOM02_ML_20200912T000000Z_regrid7km.nc"
 
         elif server == "dkrz":
-            dirname = "/work/bb1376/data/icon/atlantic-cases/paulette/ifces2-atlanXL-20200907-exp021/POSTPROC/"
+            dirname = "/work/bb1376/data/synsatipy/example-data/ifces2"
             fname = f"{dirname}/3d_full_base_DOM02_ML_20200912T000000Z_regrid7km.nc"
 
-    return fname
+
+    if example_name == 'hamlite01':
+
+
+        if server == "dkrz":
+            dirname = "/work/bb1376/data/synsatipy/example-data/hamlite"
+            fname = f"{dirname}/lam_hra_2025_atm_3d_dyn_ml_20250530T030000Z.nc"
+            geofile = f"{dirname}/hra_DOM01.nc"
+    
+    if return_geofile:
+        return fname, geofile
+    else:
+        return fname
 
 
 if __name__ == "__main__":

--- a/synsatipy/tests/test_aerosols.py
+++ b/synsatipy/tests/test_aerosols.py
@@ -10,7 +10,6 @@ def test_modis_aerosol_init_defaults():
     - the instrument loads without error
     - AddAerosl RTTOV option is set
     - use_aerosols flag is stored on synsat attributes
-    - default aerosol_species dict is populated
     """
     s = SynSatTest(
         synsat_instrument="modis",
@@ -21,8 +20,6 @@ def test_modis_aerosol_init_defaults():
     assert s.synsat.instrument.startswith("MODIS")
     assert s.Options.AddAerosl is True
     assert s.synsat.use_aerosols is True
-    assert isinstance(s.synsat.aerosol_species, dict)
-    assert len(s.synsat.aerosol_species) > 0
 
 
 def test_modis_no_aerosol_init_defaults():

--- a/synsatipy/tests/test_aerosols.py
+++ b/synsatipy/tests/test_aerosols.py
@@ -1,0 +1,40 @@
+import pytest
+from synsat_test import SynSatTest
+
+
+def test_modis_aerosol_init_defaults():
+    """
+    Test that MODIS initialises correctly with use_aerosols=True.
+
+    Checks that:
+    - the instrument loads without error
+    - AddAerosl RTTOV option is set
+    - use_aerosols flag is stored on synsat attributes
+    - default aerosol_species dict is populated
+    """
+    s = SynSatTest(
+        synsat_instrument="modis",
+        synsat_modis_satellite="terra",
+        synsat_use_aerosols=True,
+    )
+
+    assert s.synsat.instrument.startswith("MODIS")
+    assert s.Options.AddAerosl is True
+    assert s.synsat.use_aerosols is True
+    assert isinstance(s.synsat.aerosol_species, dict)
+    assert len(s.synsat.aerosol_species) > 0
+
+
+def test_modis_no_aerosol_init_defaults():
+    """
+    Test that MODIS initialises correctly with use_aerosols=False (default).
+
+    Checks that AddAerosl is off and use_aerosols is False.
+    """
+    s = SynSatTest(synsat_instrument="modis")
+
+    assert s.synsat.use_aerosols is False
+    assert s.Options.AddAerosl is False
+
+
+

--- a/synsatipy/tests/test_data_handler.py
+++ b/synsatipy/tests/test_data_handler.py
@@ -5,16 +5,21 @@ from synsatipy.synsat_example_data import get_example_data
 
 
 @pytest.mark.parametrize(
-    "example_name",
+    "example_name, return_geofile",
     [
-        ("era01"),
-        ("icon01"),
-        ("icon02"),
+        ("era01", False),
+        ("icon01", False),
+        ("icon02", False),
+        ("hamlite01", True),
     ],
 )
-def test_input_of_example_data(example_name):
+def test_input_of_example_data(example_name, return_geofile):
 
-    filename = get_example_data(example_name)
+    if return_geofile:
+        filename, geofile = get_example_data(example_name, return_geofile=return_geofile)
+    else:
+        filename = get_example_data(example_name, return_geofile=return_geofile)
+        geofile = None
 
     d = DataHandler()
-    d.open_data(filename)
+    d.open_data(filename, geofile=geofile)

--- a/synsatipy/tests/test_example_data.py
+++ b/synsatipy/tests/test_example_data.py
@@ -1,14 +1,22 @@
+import os
 import pytest
 
 import synsatipy.synsat_example_data as synsat_example_data
 
-def test_examble_data(  ):
 
-    eraname = synsat_example_data.get_example_data( 'era01' )
+def test_examble_data():
 
-    assert 'medi' in eraname
+    eraname = synsat_example_data.get_example_data("era01")
 
-    iconname = synsat_example_data.get_example_data( 'icon01' )
+    assert "medi" in eraname
 
-    assert 'ifces2' in iconname
+    iconname = synsat_example_data.get_example_data("icon01")
 
+    assert "ifces2" in iconname
+
+
+@pytest.mark.parametrize("example_name", ["era01", "icon01", "icon02"])
+def test_example_data_file_exists(example_name):
+    """Check that the path returned by get_example_data points to an existing file."""
+    fname = synsat_example_data.get_example_data(example_name)
+    assert os.path.isfile(fname), f"Example data file not found: {fname}"

--- a/synsatipy/tests/test_example_data.py
+++ b/synsatipy/tests/test_example_data.py
@@ -14,8 +14,11 @@ def test_examble_data():
 
     assert "ifces2" in iconname
 
+    hamlitename = synsat_example_data.get_example_data("hamlite01")
 
-@pytest.mark.parametrize("example_name", ["era01", "icon01", "icon02"])
+    assert "hamlite" in hamlitename
+
+@pytest.mark.parametrize("example_name", ["era01", "icon01", "icon02", "hamlite01"])
 def test_example_data_file_exists(example_name):
     """Check that the path returned by get_example_data points to an existing file."""
     fname = synsat_example_data.get_example_data(example_name)

--- a/synsatipy/tests/test_example_data.py
+++ b/synsatipy/tests/test_example_data.py
@@ -4,7 +4,7 @@ import pytest
 import synsatipy.synsat_example_data as synsat_example_data
 
 
-def test_examble_data():
+def test_example_data():
 
     eraname = synsat_example_data.get_example_data("era01")
 

--- a/synsatipy/tests/test_instruments.py
+++ b/synsatipy/tests/test_instruments.py
@@ -10,6 +10,10 @@ from synsat_test import SynSatTest
     {"instrument": "abi", "goes_number": 16, "channels": (13, 14, 15)},
     # Test FCI with default channels
     {"instrument": "fci", "mtg_number": 1, "channels": (13, 14, 15)},
+    # Test MODIS/Terra with default channels
+    {"instrument": "modis", "modis_satellite": "terra", "channels": (31, 32, 33)},
+    # Test MODIS/Aqua with default channels
+    {"instrument": "modis", "modis_satellite": "aqua", "channels": (31, 32, 33)},
 ])
 def test_instrument_workflow(instrument_config):
     """
@@ -34,12 +38,15 @@ def test_instrument_workflow(instrument_config):
         kwargs["synsat_goes_number"] = instrument_config["goes_number"]
     elif instrument == "fci":
         kwargs["synsat_mtg_number"] = instrument_config["mtg_number"]
+    elif instrument == "modis":
+        kwargs["synsat_modis_satellite"] = instrument_config["modis_satellite"]
     
     # Initialize SynSatTest with the specified instrument
     s = SynSatTest(**kwargs)
     
     # Verify instrument was loaded correctly
-    assert s.synsat.instrument.upper() == instrument.upper()
+    # Note: MODIS sets instrument to e.g. "MODIS (Terra)" so use startswith
+    assert s.synsat.instrument.upper().startswith(instrument.upper())
     
     # Verify channels configuration
     assert s.synsat.chan_list_instrument == channels
@@ -193,3 +200,63 @@ def test_load_fci_single_channel():
     
     # Check channels attribute contains the right variable
     assert "bt105" in s.synsat.channels
+
+
+def test_load_modis_terra_default_channels():
+    """
+    Tests loading the MODIS instrument on Terra with default channel list.
+
+    Verifies that MODIS/Terra can be loaded without errors and
+    the default channels are set correctly.
+    """
+    s = SynSatTest(synsat_instrument="modis", synsat_modis_satellite="terra")
+
+    # Check instrument name includes Terra
+    assert s.synsat.instrument == "MODIS (Terra)"
+
+    # Default channel list for MODIS should be (20, 22, 27, 28, 29, 31, 32, 33)
+    assert s.synsat.chan_list_instrument == (20, 22, 27, 28, 29, 31, 32, 33)
+    assert s.synsat.nchan_instrument == 8
+
+    # Check that coefficient files reference eos_1
+    assert "rtcoef_eos_1_modis" in s.FileCoef
+    assert "sccldcoef_eos_1_modis" in s.FileSccld
+
+
+def test_load_modis_aqua_default_channels():
+    """
+    Tests loading the MODIS instrument on Aqua with default channel list.
+
+    Verifies that MODIS/Aqua can be loaded without errors and
+    the default channels are set correctly.
+    """
+    s = SynSatTest(synsat_instrument="modis", synsat_modis_satellite="aqua")
+
+    # Check instrument name includes Aqua
+    assert s.synsat.instrument == "MODIS (Aqua)"
+
+    # Default channel list for MODIS should be (20, 22, 27, 28, 29, 31, 32, 33)
+    assert s.synsat.chan_list_instrument == (20, 22, 27, 28, 29, 31, 32, 33)
+    assert s.synsat.nchan_instrument == 8
+
+    # Check that coefficient files reference eos_2
+    assert "rtcoef_eos_2_modis" in s.FileCoef
+    assert "sccldcoef_eos_2_modis" in s.FileSccld
+
+
+def test_load_modis_single_channel():
+    """
+    Tests loading the MODIS instrument with a single thermal window channel.
+
+    Verifies that MODIS can be loaded with a custom channel list
+    containing just one channel.
+    """
+    # Channel 31 - 10.780-11.280 µm - Surface/Cloud Temperature
+    s = SynSatTest(synsat_instrument="modis", synsat_channel_list=(31,))
+
+    assert s.synsat.instrument.startswith("MODIS")
+    assert s.synsat.chan_list_instrument == (31,)
+    assert s.synsat.nchan_instrument == 1
+
+    # bt110 corresponds to band 31 (11.03 µm → 110)
+    assert "bt110" in s.synsat.channels

--- a/synsatipy/utils/aerosoltools.py
+++ b/synsatipy/utils/aerosoltools.py
@@ -6,28 +6,28 @@ _default_aerosol_config = {
         "radius": 8e-08,
         "density": 1993.0,
         "sigma": 1.59,
-        "CAMS_OPAC_name": '"SOOT"',
+        "CAMS_OPAC_name": "BCAR",
         "target_name": "qca",
     },
     "num_qsu": {
         "radius": 1.4e-07,
         "density": 1859.0,
         "sigma": 1.59,
-        "CAMS_OPAC_name": '"SULP"',
+        "CAMS_OPAC_name": "SULP",
         "target_name": "qsu",
     },
     "num_qss": {
         "radius": 8.5e-07,
         "density": 2165.0,
         "sigma": 2.0,
-        "CAMS_OPAC_name": '"SSA2"',
+        "CAMS_OPAC_name": "SSA2",
         "target_name": "qss",
     },
     "num_qdu": {
         "radius": 6e-07,
         "density": 2650.0,
         "sigma": 2.0,
-        "CAMS_OPAC_name": '"DUS2"',
+        "CAMS_OPAC_name": "DUS2",
         "target_name": "qdu",
     },
 }
@@ -128,8 +128,6 @@ def convert_hamlite_numberconc_in_massconc(hamlite, config):
             (dimensionless, > 1).
         density : float
             Material (bulk) density of the aerosol species [kg m⁻³].
-            Note: key is spelled ``'denisty'`` in the current implementation
-            (typo preserved for backwards compatibility).
         target_name : str
             Name of the output variable in the returned dataset.
 
@@ -156,9 +154,11 @@ def convert_hamlite_numberconc_in_massconc(hamlite, config):
     --------
     >>> config = {
     ...     "so4_a1": {
-    ...         "radius": 0.1e-6, "sigma": 1.5,
-    ...         "denisty": 1800.0, "target_name": "aer_so4"
-    ...     }
+    ...         "radius": 0.1e-6, 
+                "sigma": 1.5,
+    ...         "density": 1800.0, 
+                "target_name": "aer_so4",
+    ...         "OPAC_name": "SULP"}, 
     ... }
     >>> hamlite_mass = convert_hamlite_numberconc_in_massconc(hamlite, config)
     """

--- a/synsatipy/utils/aerosoltools.py
+++ b/synsatipy/utils/aerosoltools.py
@@ -33,6 +33,19 @@ _default_aerosol_config = {
 }
 
 
+_cams_rttov_id_mapping = {
+    "BCAR": 81,  # Black carbon
+    "DUS1": 82,  # Mineral dust – fine mode
+    "DUS2": 83,  # Mineral dust – medium mode
+    "DUS3": 84,  # Mineral dust – coarse mode
+    "SULP": 85,  # Sulphate
+    "SSA1": 86,  # Sea salt – fine mode
+    "SSA2": 87,  # Sea salt – medium mode
+    "SSA3": 88,  # Sea salt – coarse mode
+    "OMAT": 89,  # Organic matter
+}
+
+
 def get_aerosol_particle_mass(r_geometric, sigma, rho):
     """
     Compute the mass of a single aerosol particle from lognormal size distribution parameters.

--- a/synsatipy/utils/aerosoltools.py
+++ b/synsatipy/utils/aerosoltools.py
@@ -1,0 +1,197 @@
+import numpy as np
+import xarray as xr
+
+_default_aerosol_config = {
+    "num_qca": {
+        "radius": 8e-08,
+        "density": 1993.0,
+        "sigma": 1.59,
+        "CAMS_OPAC_name": '"SOOT"',
+        "target_name": "qca",
+    },
+    "num_qsu": {
+        "radius": 1.4e-07,
+        "density": 1859.0,
+        "sigma": 1.59,
+        "CAMS_OPAC_name": '"SULP"',
+        "target_name": "qsu",
+    },
+    "num_qss": {
+        "radius": 8.5e-07,
+        "density": 2165.0,
+        "sigma": 2.0,
+        "CAMS_OPAC_name": '"SSA2"',
+        "target_name": "qss",
+    },
+    "num_qdu": {
+        "radius": 6e-07,
+        "density": 2650.0,
+        "sigma": 2.0,
+        "CAMS_OPAC_name": '"DUS2"',
+        "target_name": "qdu",
+    },
+}
+
+
+def get_aerosol_particle_mass(r_geometric, sigma, rho):
+    """
+    Compute the mass of a single aerosol particle from lognormal size distribution parameters.
+
+    Assumes a lognormal number size distribution. The volumetric (mass-equivalent)
+    radius is derived from the geometric mean radius using the third moment of the
+    lognormal distribution, and the particle mass is then obtained from its volume
+    and material density.
+
+    Parameters
+    ----------
+    r_geometric : float or array_like
+        Geometric mean radius of the lognormal size distribution [m].
+    sigma : float or array_like
+        Geometric standard deviation of the lognormal size distribution
+        (dimensionless, > 1).
+    rho : float or array_like
+        Material (bulk) density of the aerosol species [kg m⁻³].
+
+    Returns
+    -------
+    m_particle : float or numpy.ndarray
+        Mass of a single aerosol particle [kg].
+
+    Notes
+    -----
+    The volumetric radius is computed as:
+
+    .. math::
+
+        r_{\\mathrm{vol}} = r_{\\mathrm{geo}} \\cdot \\exp\\!\\left(\\frac{3}{2} \\ln^2 \\sigma\\right)
+
+    and the particle mass as:
+
+    .. math::
+
+        m = \\frac{4}{3} \\pi r_{\\mathrm{vol}}^3 \\cdot \\rho
+
+    Examples
+    --------
+    >>> get_aerosol_particle_mass(r_geometric=0.1e-6, sigma=1.5, rho=1800.0)
+    """
+    # --- Lognormal parameters ---
+    ln_sigma = np.log(sigma)
+    moment3_factor = np.exp(1.5 * ln_sigma**2)
+    r_vol = r_geometric * moment3_factor  # Volumetric Radius
+
+    # --- Single-particle mass ---
+    volume = (4.0 / 3.0) * np.pi * r_vol**3  # [m3]
+    m_particle = volume * rho  # [kg]
+    return m_particle
+
+
+#####################################################################
+#####################################################################
+
+
+def convert_hamlite_numberconc_in_massconc(hamlite, config):
+    """
+    Convert HAMLite aerosol number concentrations to mass concentrations.
+
+    Iterates over the aerosol species defined in ``config``, computes the
+    single-particle mass from lognormal size distribution parameters, and
+    multiplies by the number concentration to obtain mass concentration.
+
+    Parameters
+    ----------
+    hamlite : xarray.Dataset
+        HAMLite model dataset containing aerosol number concentration fields.
+        Variable names must match the keys in ``config``.
+    config : dict
+        Configuration dictionary for aerosol species. Each key is the name of
+        an aerosol variable in ``hamlite``, and the corresponding value is a
+        dict with the following entries:
+
+        radius : float
+            Geometric mean radius of the lognormal size distribution [m].
+        sigma : float
+            Geometric standard deviation of the lognormal size distribution
+            (dimensionless, > 1).
+        density : float
+            Material (bulk) density of the aerosol species [kg m⁻³].
+            Note: key is spelled ``'denisty'`` in the current implementation
+            (typo preserved for backwards compatibility).
+        target_name : str
+            Name of the output variable in the returned dataset.
+
+    Returns
+    -------
+    hamlite_mass : xarray.Dataset
+        Dataset with the same structure as ``hamlite`` but with aerosol
+        variables converted to mass concentration [kg m⁻³].
+
+    Notes
+    -----
+    Species present in ``config`` but absent from ``hamlite`` are silently
+    skipped. The conversion is:
+
+    .. math::
+
+        c_{\\mathrm{mass}} = N \\cdot m_{\\mathrm{particle}}
+
+    where :math:`N` is the number concentration [m⁻³] and
+    :math:`m_{\\mathrm{particle}}` is computed by
+    :func:`get_aerosol_particle_mass`.
+
+    Examples
+    --------
+    >>> config = {
+    ...     "so4_a1": {
+    ...         "radius": 0.1e-6, "sigma": 1.5,
+    ...         "denisty": 1800.0, "target_name": "aer_so4"
+    ...     }
+    ... }
+    >>> hamlite_mass = convert_hamlite_numberconc_in_massconc(hamlite, config)
+    """
+
+    hamlite_mass = xr.Dataset()
+
+    for aerosol_name in config:
+
+        print(f"Processing aerosol species '{aerosol_name}'...")
+        # get particle props
+        radius = config[aerosol_name]["radius"]
+        sigma = config[aerosol_name]["sigma"]
+        density = config[aerosol_name]["density"]
+        target_name = config[aerosol_name]["target_name"]
+
+        # get particle mass
+        aerosol_particle_mass = get_aerosol_particle_mass(radius, sigma, density)
+
+        # do conversion
+        if aerosol_name in hamlite:
+            hamlite_mass[target_name] = hamlite[aerosol_name] * aerosol_particle_mass
+
+    return hamlite_mass
+
+
+######################################################################
+######################################################################
+
+def target_name_list( config ):
+    """
+    Get the list of target variable names from the aerosol config.
+
+    Parameters
+    ----------
+    config : dict
+        Configuration dictionary for aerosol species. Each key is the name of
+        an aerosol variable, and the corresponding value is a dict with a
+        'target_name' entry.    
+
+    Returns
+    -------
+    target_names : list of str
+        List of target variable names for the aerosol species defined in the config.
+
+    """
+
+    target_names = [ config[aerosol_name]["target_name"] for aerosol_name in config ]
+
+    return target_names


### PR DESCRIPTION
## Aerosol Support & MODIS/EOS Instrument Integration

### Summary

This PR brings comprehensive capabilities for aerosol impacts on radiative calculations and adds support for EOS MODIS satellite data to SynSatiPy. The release includes a new `aerosoltools` module for CAMS/OPAC species mapping, HAMlite aerosol processing, MODIS/Terra/Aqua instrument support (all 36 bands), and several core data processing improvements.

---

### Major Features

#### 🌍 **Aerosol Support** 
- New `aerosoltools` module with CAMS/OPAC aerosol species mapping and number-to-mass conversion
- Configurable aerosol workflows via `use_aerosols` parameter in DataHandler and SynSat
- HAMlite aerosol processing pipeline with automatic aerosol file detection and integration
- RTTOV aerosol coefficient file support (`FileScaer`)

#### 🛰️ **MODIS/EOS Instrument Support**
- New `load_eos_modis()` method supporting EOS-1 (Terra) and EOS-2 (Aqua) satellites
- Full 36-band support (0.4–14.4 μm) with intelligent default channel selection (bands 20, 22, 27–29, 31–33)
- Polar-orbiting geometry handling with dynamic subsatellite longitude support
- Satellite-specific coefficient file integration

#### 📊 **Data Handler & Processing Enhancements**
- HAMlite flavor detection with configurable geofile input support
- Pressure level ordering detection for correct surface variable assignment
- Optional nadir-only viewing geometry (`lon0=None`)
- New `hamlite01` example dataset configuration

---

### Technical Changes

**Core Processing:**
- Gas stacking refactored to accommodate aerosol species (list-based approach replacing `np.stack()`)
- GasId mapping extended to include aerosol RTTOV IDs (81–89)
- Improved surface humidity extraction logic based on pressure ordering

**Instrument Configuration:**
- `load_instrument()` extended to support `"modis"` alongside `"seviri"`, `"abi"`, and `"fci"`
- HAMlite file naming refactored with explicit `hamlite-aerosols` flavor variant

**Testing & Infrastructure:**
- Parametrized MODIS satellite variant tests (Terra/Aqua)
- Centralized example data paths in `/work/bb1376/data/synsatipy/example-data/`
- Test infrastructure updated for geofile return options

---

### Checklist

- [x] Code changes align with project style and conventions
- [x] CHANGELOG.md updated with v1.2.0 entry
- [x] All tests pass locally
- [x] New features documented in docstrings
- [x] Backward compatibility maintained (aerosol support is opt-in)

---

### Related Issues

Closes: #15 